### PR TITLE
不兼容API修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 > 请注意：在使用 DashScope4j 时，你需要遵守灵积API的使用条款和条件。
 
 ## 重要更新
+- **2.1.0：** 不兼容API修复
+  - 修复模块中错误的exports，该修复会将模块中不应该暴露的内部api重新收回。本次修复不向下兼容。
+  - 修复ChatRequest中函数调用因为Message序列化问题丢失PluginCall、Plugin、ToolCall、Tool等信息的BUG
 - **2.0.0：** 大版本重构。核心API进行不兼容调整和实现重构（请注意），删除1.x.x版本被标记为已废弃的方法
   - 重构拦截器接口和实现重构，并添加了流控、重试等拦截器实现
   - 调整部分类、API的位置和命名；删除已废弃的方法
@@ -69,7 +72,7 @@ final var request = ChatRequest.newBuilder()
 <dependency>
     <groupId>io.github.oldmanpushcart</groupId>
     <artifactId>dashscope4j</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.oldmanpushcart</groupId>
     <artifactId>dashscope4j</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <name>dashscope4j ${project.version}</name>
 
     <description>Java library for DashScope</description>

--- a/src/main/java/io/github/oldmanpushcart/internal/dashscope4j/chat/message/MessageImpl.java
+++ b/src/main/java/io/github/oldmanpushcart/internal/dashscope4j/chat/message/MessageImpl.java
@@ -1,5 +1,6 @@
 package io.github.oldmanpushcart.internal.dashscope4j.chat.message;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.oldmanpushcart.dashscope4j.chat.message.Content;
 import io.github.oldmanpushcart.dashscope4j.chat.message.Message;
 
@@ -20,6 +21,7 @@ public class MessageImpl implements Message {
         this.contents.addAll(contents);
     }
 
+    @JsonProperty("role")
     @Override
     public Message.Role role() {
         return role;

--- a/src/main/java/io/github/oldmanpushcart/internal/dashscope4j/util/JacksonUtils.java
+++ b/src/main/java/io/github/oldmanpushcart/internal/dashscope4j/util/JacksonUtils.java
@@ -25,7 +25,8 @@ public class JacksonUtils {
 
     /**
      * 压缩Json字符串
-     * @param json   json
+     *
+     * @param json json
      * @return json
      */
     public static String compact(String json) {
@@ -35,7 +36,7 @@ public class JacksonUtils {
     /**
      * {@code json -> node}
      *
-     * @param json   json
+     * @param json json
      * @return node
      */
     public static JsonNode toNode(String json) {
@@ -44,6 +45,16 @@ public class JacksonUtils {
         } catch (JsonProcessingException cause) {
             throw new RuntimeException("parse json to node failed!", cause);
         }
+    }
+
+    /**
+     * {@code object -> node}
+     *
+     * @param object object
+     * @return node
+     */
+    public static JsonNode toNode(Object object) {
+        return mapper.valueToTree(object);
     }
 
     /**

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,9 +7,7 @@ open module dashscope4j {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.module.jsonSchema;
 
-
     exports io.github.oldmanpushcart.dashscope4j;
-
     exports io.github.oldmanpushcart.dashscope4j.base;
     exports io.github.oldmanpushcart.dashscope4j.base.algo;
     exports io.github.oldmanpushcart.dashscope4j.base.api;
@@ -18,8 +16,8 @@ open module dashscope4j {
     exports io.github.oldmanpushcart.dashscope4j.base.store;
     exports io.github.oldmanpushcart.dashscope4j.base.cache;
     exports io.github.oldmanpushcart.dashscope4j.base.interceptor;
-    exports io.github.oldmanpushcart.dashscope4j.base.interceptor.spec.process;
     exports io.github.oldmanpushcart.dashscope4j.base.interceptor.spec.ratelimit;
+    exports io.github.oldmanpushcart.dashscope4j.base.interceptor.spec.process;
     exports io.github.oldmanpushcart.dashscope4j.base.interceptor.spec.retry;
 
     exports io.github.oldmanpushcart.dashscope4j.chat;
@@ -36,6 +34,5 @@ open module dashscope4j {
     exports io.github.oldmanpushcart.dashscope4j.embedding.mm;
 
     exports io.github.oldmanpushcart.dashscope4j.util;
-    exports io.github.oldmanpushcart.internal.dashscope4j.util;
 
 }


### PR DESCRIPTION
  - 修复模块中错误的exports，该修复会将模块中不应该暴露的内部api重新收回。本次修复不向下兼容。
  - 修复ChatRequest中函数调用因为Message序列化问题丢失PluginCall、Plugin、ToolCall、Tool等信息的BUG